### PR TITLE
Enable SimpleCov code coverage in CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -53,3 +53,10 @@ jobs:
       - name: specs
         run: |
           bundle exec rspec
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@master
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,8 @@
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  minimum_coverage 90
+  maximum_coverage_drop 2
+end
 
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
Closes: https://github.com/belgamo/comarev/issues/15

### What?

Enable simplecov coverage gem in CI.
Adding minimum coverage setting to 90%.

### Why?

This way we can keep the code coverage next to 100%.

### How to test?

Just looking if the GH actions creates an artefact (coverage.zip) file, with the coverage generated by simplecov.

![image](https://user-images.githubusercontent.com/47258878/136069365-37cd9d17-048b-4b8d-87ab-948e98243c62.png)
